### PR TITLE
async storage for persisting tourId

### DIFF
--- a/src/components/CuriousEdinburgh.js
+++ b/src/components/CuriousEdinburgh.js
@@ -10,12 +10,10 @@ import WordPress from '../services/WordPress';
 import Tour from '../models/Tour';
 import TourPlace from '../models/TourPlace';
 import Location from '../models/Location';
+import Preference from '../models/Preference';
 
 // Utils
 import Utils from '../utils';
-
-// Constants
-import * as constants from '../constants';
 
 // Components
 import Header from './Header';
@@ -51,15 +49,16 @@ export default class CuriousEdinburgh extends Component {
                         description: category.description,
                         slug: category.slug }));
             this.setState({ tours });
-            // Following statement will be modified when tackling issue #25
-            this.changeSelectedTour(constants.DEFAULT_TOUR_ID);
+            Preference.getTourId().then(tourId => this.changeSelectedTour(tourId));
             if (Platform.OS === 'android') {
                 SplashScreen.hide();
             }
         });
     }
     componentWillUpdate(nextProps, nextState) {
-        console.log('componentWillUpdate(%o, %o)', nextProps, nextState);
+        if (this.state.selectedTour !== nextState.selectedTour) {
+            Preference.setTourId(nextState.selectedTour.id);
+        }
     }
     changeSelectedTour(tourId) {
         let tour = this.state.tours.find(element => element.id === tourId);

--- a/src/models/Preference.js
+++ b/src/models/Preference.js
@@ -1,0 +1,21 @@
+import { AsyncStorage } from 'react-native';
+import * as constants from '../constants';
+
+export default class Preference {
+    static async getTourId() {
+        try {
+            const tourId = await AsyncStorage.getItem('tourId');
+            return tourId !== null ? tourId : constants.DEFAULT_TOUR_ID;
+        } catch (error) {
+            return constants.DEFAULT_TOUR_ID;
+        }
+    }
+    static async setTourId(value) {
+        try {
+            await AsyncStorage.setItem('tourId', value);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Async storage created for persisting a tourId whenever the default is changed.

- Created src/models/Preference.js
- Modified src/components/CuriousEdinburgh.js

I have manually tested the issue on iOS device by:

1. Open the app (ensuring is a brand new installation)
2. Selecting History of Physics
3. Close the app (remove from background)
4. Open the app again and verify History of Physics is my default tour