### PR TITLE
Direction Objects from MapBox to create path between TourPlaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-native-maps": "0.13.0",
     "react-native-scrollable-tab-view": "0.7.0",
     "react-native-splash-screen": "2.0.0",
-    "react-native-vector-icons": "4.0.0"
+    "react-native-vector-icons": "4.0.0",
+    "shortid": "^2.2.6"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/src/components/TourMap/index.js
+++ b/src/components/TourMap/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import MapView from 'react-native-maps';
+import Tour from '../../models/Tour';
 import TourPlaceCallout from './TourPlaceCallout';
 import TourRecord from '../TourRecord';
 
@@ -25,6 +26,7 @@ export default class TourMap extends Component {
         this.mapRef = null;
         this.modal = null;
         this.onMarkerPress = this.onMarkerPress.bind(this);
+        this.state = { showModal: false };
     }
     componentDidMount() {
         this.centerMap();
@@ -36,14 +38,14 @@ export default class TourMap extends Component {
         this.modal.show(tourPlace);
     }
     centerMap() {
-        const markerIDs = this.props.tourPlaces.map(tourPlace =>
+        const markerIDs = this.props.tour.tourPlaces.map(tourPlace =>
             tourPlace.id);
         if (this.mapRef !== null) {
             this.mapRef.fitToSuppliedMarkers(markerIDs, false);
         }
     }
     render() {
-        const listMarkers = this.props.tourPlaces.map(tourPlace =>
+        const listMarkers = this.props.tour.tourPlaces.map(tourPlace =>
           <MapView.Marker
             key={tourPlace.id}
             identifier={tourPlace.id}
@@ -59,6 +61,8 @@ export default class TourMap extends Component {
               />
             </MapView.Callout>
           </MapView.Marker>);
+        const polylines = this.props.tour.directions.map(direction =>
+          <MapView.Polyline key={direction.id} coordinates={direction.coordinates} />);
         return (
           <View style={styles.map}>
             <MapView
@@ -66,6 +70,7 @@ export default class TourMap extends Component {
               style={styles.map}
             >
               {listMarkers}
+              {polylines}
             </MapView>
             <TourRecord
               ref={(c) => { this.modal = c; }}
@@ -74,6 +79,9 @@ export default class TourMap extends Component {
         );
     }
 }
+TourMap.defaultProps = {
+    tour: new Tour(),
+};
 TourMap.propTypes = {
-    tourPlaces: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    tour: React.PropTypes.instanceOf(Tour),
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+import Location from './models/Location';
+
 /* http://v2.wp-api.org/ documentation API for WordPress */
 export const URL = 'http://curiousedinburgh.org';
 export const UPLOADS_URL = `${URL}/wp-content/uploads`;
@@ -7,3 +9,14 @@ export const MAX_NUM_POSTS = '100';
 export const CATEGORIES = `${WP_JSON}/categories?per_page=${MAX_NUM_CATEGORIES}`;
 export const POSTS_BY_CATEGORY = `${WP_JSON}/posts?per_page=${MAX_NUM_POSTS}&categories=`;
 export const DEFAULT_TOUR_ID = '4'; // History of Science
+export const MAPBOX_ACCESS_TOKEN = 'pk.eyJ1Ijoiam9sbG9wcmUiLCJhIjoiY2l6ZWE0YnVmMDA3MzMycGVkZjlkN3E3ayJ9.VZ0Ih1aDaRKlUTPBtkfPng';
+export function MAPBOX_URL_DIRECTIONS(locationStart, locationEnd) {
+    if (!(locationStart instanceof Location)) {
+        throw new TypeError('Location object is expected for locationStart');
+    } else if (!(locationEnd instanceof Location)) {
+        throw new TypeError('Location object is expected for locationEnd');
+    }
+    const coordinates = `${locationStart.longitude},${locationStart.latitude};${locationEnd.longitude},${locationEnd.latitude}`;
+    return `https://api.mapbox.com/directions/v5/mapbox/walking/${coordinates}?access_token=${MAPBOX_ACCESS_TOKEN}&geometries=geojson`;
+}
+

--- a/src/models/Direction.js
+++ b/src/models/Direction.js
@@ -1,0 +1,9 @@
+import shortid from 'shortid';
+
+export default class Direction {
+    // coordinates should be an Array of Location
+    constructor({ coordinates = [] } = {}) {
+        this.id = shortid.generate();
+        this.coordinates = coordinates; // Represents an Array of Location objects
+    }
+}

--- a/src/models/Location.js
+++ b/src/models/Location.js
@@ -1,6 +1,6 @@
 export default class Location {
-    constructor(latitude, longitude) {
-        this.latitude = latitude;   // Number
-        this.longitude = longitude; // Number
+    constructor({ latitude = 0.0, longitude = 0.0 } = {}) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/src/models/Tour.js
+++ b/src/models/Tour.js
@@ -1,9 +1,10 @@
 export default class Tour {
-    constructor({ id = '', name = '', description = '', slug = '', tourPlaces = [] } = {}) {
+    constructor({ id = '', name = '', description = '', slug = '', tourPlaces = [], directions = [] } = {}) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.slug = slug;
         this.tourPlaces = tourPlaces;
+        this.directions = directions; // Represents an Array of Direction objects
     }
 }

--- a/src/services/MapBox.js
+++ b/src/services/MapBox.js
@@ -1,0 +1,97 @@
+import * as constants from '../constants';
+import Location from '../models/Location';
+import Direction from '../models/Direction';
+/* global fetch:false*/
+export default class MapBox {
+    /*
+      @locationStart represents a Location object
+      @locationEnd represents a Location object
+      returns a Promise object. A fullfilled promise contains a Direction object.
+      A rejected promise returns an object (e.g { status: String, statusText: String}).
+    */
+    static getDirection(locationStart, locationEnd) {
+        const p1 = new Promise((resolve, reject) => {
+            let URL = null;
+            try {
+                URL = constants.MAPBOX_URL_DIRECTIONS(locationStart, locationEnd);
+            } catch (e) {
+                reject({ statusText: e.message });
+            }
+            if (URL !== null) {
+                fetch(URL, {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json; charset=utf-8',
+                    },
+                }).then((onFullfilled) => {
+                    if (onFullfilled.ok) {
+                        resolve(onFullfilled.json());
+                    } else {
+                        reject({ status: onFullfilled.status,
+                            statusText: onFullfilled.statusText });
+                    }
+                }, (onRejected) => {
+                    reject({ statusText: onRejected });
+                });
+            }
+        });
+        const p2 = new Promise((resolve, reject) => {
+            p1.then((data) => {
+                if (Array.isArray(data.routes)
+                  && data.routes[0]
+                  && data.routes[0].geometry
+                  && Array.isArray(data.routes[0].geometry.coordinates)) {
+                    const coordinates = data.routes[0].geometry.coordinates.map(value =>
+                      new Location({
+                          latitude: parseFloat(value[1]),
+                          longitude: parseFloat(value[0]) }));
+                    resolve(new Direction({ coordinates }));
+                } else {
+                    reject({ statusText: 'geometry coordinates is not an Array property' });
+                }
+            }, (onRejected) => {
+                reject(onRejected);
+            });
+        });
+        return p2;
+    }
+    /*
+      This method is intended to obtain an Array of Direction objects given an Array of
+      Location objects. These Direction objects are calculated by passing each position of the
+      Array of Location objects with its nearest greater position to the MapBox.getDirection.
+      @locations is an Array of Location objects
+      returns a Promise object. A fullfilled promise contains An Array of Direction objects.
+      A rejected promise returns an object (e.g { status: String, statusText: String}).
+    */
+    static getDirections(locations) {
+        if (!Array.isArray(locations)) {
+            return Promise.reject({ statusText: 'An array of locations is expected' });
+        } else if (locations.length < 2) {
+            return Promise.resolve([]);
+        }
+        const p1 = new Promise((resolve, reject) => {
+            const promisesCreated = locations.length - 1;
+            let completed = 0;
+            const directions = [];
+            const intervalID = setInterval(() => {
+                if (completed === promisesCreated) {
+                    clearInterval(intervalID);
+                    resolve(directions);
+                }
+            }, 100);
+            locations.forEach((currentValue, index) => {
+                if (index + 1 < locations.length) {
+                    MapBox.getDirection(currentValue, locations[index + 1]).then((data) => {
+                        directions.push(data);
+                        completed += 1;
+                    }, (onRejected) => {
+                        completed = locations.length - 1;
+                        clearInterval(intervalID);
+                        reject(onRejected);
+                    });
+                }
+            });
+        });
+        return p1;
+    }
+}


### PR DESCRIPTION
A first attempt to create path between TourPlaces. A brief description of the work done:

- A service model talking to MapBox
- Tour directions cached on the object (as long as the user does not close the app)
- TourMap receiving a tour object as property rather than tourPlaces

TODO:

- Toggle to display/hide paths.

- Checking the routes drawn on Android devices (iOS lines sometimes does not respect streets)